### PR TITLE
Fixes cat9.add_job_suggestions and ensures it's usage

### DIFF
--- a/cat9/base/misc.lua
+++ b/cat9/base/misc.lua
@@ -381,16 +381,18 @@ function cat9.from_b64(b64)
 end
 
 function cat9.add_job_suggestions(set, allow_hidden, filter)
-	if cat9.selectedjob then
+	local filter = filter or function() return true end
+
+	if cat9.selectedjob and filter(cat9.selectedjob) then
 		table.insert(set, "#csel")
 	end
-	if cat9.latestjob then
+
+	if cat9.latestjob and filter(cat9.latestjob) then
 		table.insert(set, "#last")
 	end
+
 	for _,v in ipairs(lash.jobs) do
-		if
-			(filter and filter(v)) and
-			(not v.hidden or allow_hidden) then
+		if filter(v) and (not v.hidden or allow_hidden) then
 			table.insert(set, "#" .. tostring(v.id))
 			if v.alias then
 				table.insert(set, "#" .. v.alias)

--- a/cat9/default/cd.lua
+++ b/cat9/default/cd.lua
@@ -130,11 +130,11 @@ function suggest.cd(args, raw)
 -- special case, job references
 	if string.sub(raw, 4, 4) == "#" then
 		local set = {}
-		for _,v in ipairs(lash.jobs) do
-			if v.dir and v.id then
-				table.insert(set, "#" .. tostring(v.id))
-			end
-		end
+
+		cat9.add_job_suggestions(set, false, function(job)
+			return job.dir ~= nil
+		end)
+
 		cat9.readline:suggest(cat9.prefix_filter(set, string.sub(raw, 4)), "word")
 		return
 	end

--- a/cat9/default/copy.lua
+++ b/cat9/default/copy.lua
@@ -337,12 +337,7 @@ local function suggest_for_src(args, raw)
 	table.insert(set, "pick:")
 	table.insert(set, "./")
 	table.insert(set, "/")
-
-	for _,v in ipairs(lash.jobs) do
-		if not v.hidden then
-			table.insert(set, "#" .. tostring(v.id))
-		end
-	end
+	cat9.add_job_suggestions(set, false)
 
 	cat9.readline:suggest(cat9.prefix_filter(set, args[2]), "word")
 	return

--- a/cat9/default/forget.lua
+++ b/cat9/default/forget.lua
@@ -210,16 +210,8 @@ function suggest.forget(args, raw)
 	local set = {}
 	local cmd = args[#args]
 
-	for _,v in ipairs(lash.jobs) do
-		if not v.pid and not v.hidden then
-			table.insert(set, "#" .. tostring(v.id))
-			if v.alias then
-				table.insert(set, "#" .. v.alias)
-			end
-		end
-	end
-
 	if #args == 2 then
+		cat9.add_job_suggestions(set, false)
 		table.insert(set, "all-passive")
 		table.insert(set, "all-bad")
 		table.insert(set, "all-hard")
@@ -228,7 +220,6 @@ function suggest.forget(args, raw)
 
 	if #args == 3 and args[2] == "lines" then
 		cat9.add_job_suggestions(set, false)
-		return
 	elseif #args > 3 and args[2] == "lines" then
 -- add_message for line-number bounds?
 		cat9.readline:suggest({})

--- a/cat9/default/input.lua
+++ b/cat9/default/input.lua
@@ -30,11 +30,11 @@ function suggest.input(args, raw)
 
 	if #args == 2 then
 		local set = {}
-		for _,v in ipairs(lash.jobs) do
-			if v.dir and v.id then
-				table.insert(set, "#" .. tostring(v.id))
-			end
-		end
+
+		cat9.add_job_suggestions(set, false, function(job)
+			return job.dir ~= nil
+		end)
+
 		cat9.readline:suggest(cat9.prefix_filter(set, args[2]), "word")
 		return
 	end

--- a/cat9/default/repeat.lua
+++ b/cat9/default/repeat.lua
@@ -90,11 +90,9 @@ function(args, raw)
 		return
 	end
 
-	for _,v in ipairs(lash.jobs) do
-		if not v.pid and not v.hidden then
-			table.insert(set, "#" .. tostring(v.id))
-		end
-	end
+	cat9.add_job_suggestions(set, false, function(job)
+		return not job.pid
+	end)
 
 	cat9.readline:suggest(set, "word")
 end

--- a/cat9/default/signal.lua
+++ b/cat9/default/signal.lua
@@ -51,6 +51,7 @@ end
 
 function suggest.signal(args, raw)
 	local set = {}
+
 	if #args > 3 then
 		cat9.add_message("signal #jobid signal : too many arguments")
 		return
@@ -61,11 +62,11 @@ function suggest.signal(args, raw)
 		return
 	end
 
-	for _,v in ipairs(lash.jobs) do
-		if v.pid and not v.hidden then
-			table.insert(set, "#" .. tostring(v.id))
-		end
-	end
+	cat9.add_job_suggestions(set, false, function(job)
+		return job.pid ~= nil
+	end)
+
+	cat9.readline:suggest(set, "word")
 end
 
 end

--- a/cat9/default/trigger.lua
+++ b/cat9/default/trigger.lua
@@ -118,12 +118,9 @@ end
 
 function suggest.trigger(args, raw)
 	local set = {}
+
 	if #args == 2 then
-		for _,v in ipairs(lash.jobs) do
-			if not v.hidden then
-				table.insert(set, "#" .. tostring(v.id))
-			end
-		end
+		cat9.add_job_suggestions(set, false)
 		cat9.readline:suggest(cat9.prefix_filter(set, args[2]), "word")
 	elseif #args == 3 then
 		cat9.readline:suggest(cat9.prefix_filter({"ok", "fail"}, args[3]), "word")


### PR DESCRIPTION
Fixes `add_job_suggestions` in case of missing filter and uses it for meta jobs if it's present.

Also ensure that builtins are using `add_job_suggestions` instead of manually replicating job suggestions logic.