### PR TITLE
Uses /usr/bin/env to lookup system binaries

### DIFF
--- a/cat9.lua
+++ b/cat9.lua
@@ -44,7 +44,8 @@ end
 local function glob_builtins(dst)
 	local arg =
 	{
-		"/usr/bin/find",
+		"/usr/bin/env",
+		"/usr/bin/env",
 		"find",
 		lash.scriptdir .. "cat9/",
 		"-maxdepth", "1",

--- a/cat9/base/scanner.lua
+++ b/cat9/base/scanner.lua
@@ -132,8 +132,9 @@ function cat9.pathexec_oracle()
 
 	local path = root:getenv()["PATH"]
 	local argv = string.split(path, ":")
-	table.insert(argv, 1, "/usr/bin/find")
-	table.insert(argv, 2, "find")
+	table.insert(argv, 1, "/usr/bin/env")
+	table.insert(argv, 2, "/usr/bin/env")
+	table.insert(argv, 3, "find")
 	table.insert(argv, "-executable")
 	local dupcheck = {}
 	cat9.path_set = {}

--- a/cat9/config/config.lua
+++ b/cat9/config/config.lua
@@ -124,8 +124,8 @@ return
 
 	glob =
 	{
-		dir_argv = {"/usr/bin/find", "find", "$path", "-maxdepth", "1", "-type", "d"},
-		file_argv = {"/usr/bin/find", "find", "$path", "-maxdepth", "1"}
+		dir_argv = {"/usr/bin/env", "/usr/bin/env", "find", "$path", "-maxdepth", "1", "-type", "d"},
+		file_argv = {"/usr/bin/env", "/usr/bin/env", "find", "$path", "-maxdepth", "1"}
 	},
 
 -- each set of builtins (including the default) gets a subtable in here that

--- a/cat9/config/system.lua
+++ b/cat9/config/system.lua
@@ -14,7 +14,9 @@ return
 		verbose = false,
 		hidden = false,
 		watch = {
-			"/usr/bin/inotifywait", "inotifywait",
+			"/usr/bin/env",
+			"/usr/bin/env",
+			"inotifywait",
 			"-e", "move",
 			"-e", "create",
 			"-e", "delete",

--- a/cat9/default/open.lua
+++ b/cat9/default/open.lua
@@ -36,7 +36,7 @@ local function fname_to_decode(cat9, root, dstenv, wdir, fn, closure)
 	root:chdir(wdir)
 
 	cat9.set_scanner(
-		{"/usr/bin/file", "file", "-b", "--mime-type", fn},
+		{"/usr/bin/env", "/usr/bin/env", "file", "-b", "--mime-type", fn},
 		function(res)
 			local proto
 			if res and res[1] then

--- a/cat9/system/list.lua
+++ b/cat9/system/list.lua
@@ -93,9 +93,9 @@ local function queue_ls(src, path)
 		path = resolve_path(src.dir .. "/" .. path)
 	end
 
-	local _, out, _, pid = root:popen({"/bin/ls", "cat9-ls", "-1aFb", path}, "r")
+	local _, out, _, pid = root:popen({"/usr/bin/env", "/usr/bin/env", "ls", "-1aFb", path}, "r")
 	if not pid then
-		cat9.add_message("builtin:list - couldn't spawn /bin/ls")
+		cat9.add_message("builtin:list - couldn't spawn ls")
 		return
 	end
 


### PR DESCRIPTION
This makes lash more portable by not assuming paths of system utilities. Mainly concern to distributions like NixOS that deviate from standard unix paths.